### PR TITLE
add find the sub calls that use &

### DIFF
--- a/lib/FindUnusedMethod.pm
+++ b/lib/FindUnusedMethod.pm
@@ -61,6 +61,17 @@ sub register_file {
             }
         }
     }
+
+    # &___ , &___() or \&___
+    my $symbols = $doc->find('PPI::Token::Symbol') || [];
+    for (@$symbols) {
+        next unless $_->symbol_type eq '&';
+        ( my $sub = $_->content ) =~ s/\A&//;
+        $sub = ( split '::', $sub )[-1];
+        $self->_method_called($sub);
+    }
+
+    return 1;
 }
 
 sub _method_found {


### PR DESCRIPTION
for example: &foo, &foo(), \&foo